### PR TITLE
Add release GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    name: Build and publish new release
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.7"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r dev-requirements.txt
+
+      - name: Check that versions match
+        id: version
+        run: |
+          echo "Release tag: [${{ github.event.release.tag_name }}]"
+          PACKAGE_VERSION=$(python -c "import ccds; print(ccds.__version__)")
+          echo "Package version: [$PACKAGE_VERSION]"
+          [ ${{ github.event.release.tag_name }} == "v$PACKAGE_VERSION" ] || { exit 1; }
+          echo "::set-output name=major_minor_version::v${PACKAGE_VERSION%.*}"
+
+      - name: Build package
+        run: |
+          make dist
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
@@ -35,4 +35,3 @@ jobs:
       - name: Build package
         run: |
           make dist
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,18 @@ jobs:
       - name: Build package
         run: |
           make dist
+          
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@v1.3.0
+        with:
+          user: ${{ secrets.PYPI_TEST_USERNAME }}
+          password: ${{ secrets.PYPI_TEST_PASSWORD }}
+          repository_url: https://test.pypi.org/legacy/
+          skip_existing: true
+
+      - name: Publish to Production PyPI
+        uses: pypa/gh-action-pypi-publish@v1.3.0
+        with:
+          user: ${{ secrets.PYPI_PROD_USERNAME }}
+          password: ${{ secrets.PYPI_PROD_PASSWORD }}
+          skip_existing: false

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ## UNRELEASED
 
 - Fixes issue with scaffold code that import of config did not work. Adds testing of imports to test suite. (Issue [#370](https://github.com/drivendataorg/cookiecutter-data-science/issues/370))
-- Create automated release mechanism (Issue [#316](https://github.com/drivendataorg/cookiecutter-data-science/issues/317)) and pin template version to installed release (Issue [#389](https://github.com/drivendataorg/cookiecutter-data-science/issues/389))
+- Create automated release mechanism (Issue [#317](https://github.com/drivendataorg/cookiecutter-data-science/issues/317)) and pin template version to installed release (Issue [#389](https://github.com/drivendataorg/cookiecutter-data-science/issues/389))
 
 ## v2.0.0 (2024-05-22)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Fixes issue with scaffold code that import of config did not work. Adds testing of imports to test suite. (Issue [#370](https://github.com/drivendataorg/cookiecutter-data-science/issues/370))
+- Create automated release mechanism (Issue [#316](https://github.com/drivendataorg/cookiecutter-data-science/issues/317)) and pin template version to installed release (Issue [#389](https://github.com/drivendataorg/cookiecutter-data-science/issues/389))
 
 ## v2.0.0 (2024-05-22)
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,31 @@ lint:
 	isort --check --profile black ccds hooks tests docs/scripts
 	black --check ccds hooks tests docs/scripts
 
+clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+
+clean-build: ## remove build artifacts
+	rm -fr build/
+	rm -fr dist/
+	rm -fr .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc: ## remove Python file artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-test: ## remove test and coverage artifacts
+	rm -fr .tox/
+	rm -f .coverage
+	rm -fr htmlcov/
+	rm -fr .pytest_cache
+	
+dist: clean ## builds source and wheel package
+	python -m build
+	ls -l dist
+
 
 ###     DOCS
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ The directory structure of your new project will look something like this (depen
     └── plots.py                <- Code to create visualizations   
 ```
 
+## Using unreleased changes
+
+By default, `ccds` will download the most recently _released_ version of the template. If there are any _unreleased_ changes to the template (or changes in a separate branch) that you want to incorporate, you can do so by checking out whatever branch you'd like to use (checkout `master` for the latest changes):
+
+```bash
+ccds -c master
+```
+
 ## Using v1
 
 If you want to use the old v1 project template, you need to have either the cookiecutter-data-science package or cookiecutter package installed. Then, use either command-line program with the `-c v1` option:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The directory structure of your new project will look something like this (depen
 
 ## Using unreleased changes
 
-By default, `ccds` will use the version of the template that corresponds to the installed version (e.g., if you have installed version v2.0.1, you'll use the v2.0.1 version of the template by default). If there are any _unreleased_ changes to the template (or changes in a separate branch) that you want to incorporate, you can do so by checking out whatever branch you'd like to use (checkout `master` for the latest changes):
+By default, `ccds` will use the _project template_ version that corresponds to the _installed `ccds` package_ version (e.g., if you have installed `ccds` v2.0.1, you'll use the v2.0.1 version of the project template by default). To use a specific version of the project template, use the `-c/--checkout` flag to provide the branch (or tag or commit hash) of the version you'd like to use. For example to use the project template from the `master` branch:
 
 ```bash
 ccds -c master

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The directory structure of your new project will look something like this (depen
 
 ## Using unreleased changes
 
-By default, `ccds` will download the most recently _released_ version of the template. If there are any _unreleased_ changes to the template (or changes in a separate branch) that you want to incorporate, you can do so by checking out whatever branch you'd like to use (checkout `master` for the latest changes):
+By default, `ccds` will use the version of the template that corresponds to the installed version (e.g., if you have installed version 2.0.1, you'll use the 2.0.1 version of the template by default). If there are any _unreleased_ changes to the template (or changes in a separate branch) that you want to incorporate, you can do so by checking out whatever branch you'd like to use (checkout `master` for the latest changes):
 
 ```bash
 ccds -c master

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The directory structure of your new project will look something like this (depen
 
 ## Using unreleased changes
 
-By default, `ccds` will use the version of the template that corresponds to the installed version (e.g., if you have installed version 2.0.1, you'll use the 2.0.1 version of the template by default). If there are any _unreleased_ changes to the template (or changes in a separate branch) that you want to incorporate, you can do so by checking out whatever branch you'd like to use (checkout `master` for the latest changes):
+By default, `ccds` will use the version of the template that corresponds to the installed version (e.g., if you have installed version v2.0.1, you'll use the v2.0.1 version of the template by default). If there are any _unreleased_ changes to the template (or changes in a separate branch) that you want to incorporate, you can do so by checking out whatever branch you'd like to use (checkout `master` for the latest changes):
 
 ```bash
 ccds -c master

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-The release of [ccds v2](https://drivendata.co/blog/ccds-v2) introduced the `ccds` utility and the concept of versioning to cookiecutter data science. Prior to this release, there was just the template and the use of [cookiecutter](https://github.com/cookiecutter/cookiecutter) - branches and forks could be used in the usual way to get different versions of the template.
+The release of [ccds v2](https://drivendata.co/blog/ccds-v2) introduced the `ccds` utility and the concept of versioning to cookiecutter data science. Prior to this release, cookiecutter-data-science only provided a project template, which the generic [cookiecutter](https://github.com/cookiecutter/cookiecutter) utility could use to instantiate a project. Branches and forks could be used in the usual way to get different versions of the template.
 
 To give the utility and the template a bit more stability, PR [#336](https://github.com/drivendataorg/cookiecutter-data-science/pull/336) created automated release mechanics for publishing new releases and, by default, pinned the template used by the `ccds` utility to the installed version. 
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,11 @@
+# Information for releases and versioning of ccds
+
+## Background
+
+The release of [ccds v2](https://drivendata.co/blog/ccds-v2) introduced the `ccds` utility and the concept of versioning to cookiecutter data science. Prior to this release, there was just the template and the use of [cookiecutter](https://github.com/cookiecutter/cookiecutter) - branches and forks could be used in the usual way to get different versions of the template.
+
+To give the utility and the template a bit more stability, PR [#336](https://github.com/drivendataorg/cookiecutter-data-science/pull/336) created automated release mechanics for publishing new releases and, by default, pinned the template used by the `ccds` utility to the installed version. 
+
+## Issuing a new release
+
+`ccds` uses [semantic versioning](https://semver.org/). When issuing a new release, **ensure that your release version tag has the format `vMAJOR.MINOR.PATCH`. The `v` prefix is important because the utility will look for the tag with that name to download by default.

--- a/ccds/__init__.py
+++ b/ccds/__init__.py
@@ -1,0 +1,3 @@
+from ccds.version import __version__
+
+__version__

--- a/ccds/__main__.py
+++ b/ccds/__main__.py
@@ -37,7 +37,7 @@ def default_ccds_main(f):
         # Per #389, set this to the currently released version by default
         param_names = [p.name for p in f.params]
         checkout_index = param_names.index("checkout")
-        f.params[checkout_index].default = __version__
+        f.params[checkout_index].default = f"v{__version__}"
         return f(*args, **kwargs)
 
     return _main

--- a/ccds/__main__.py
+++ b/ccds/__main__.py
@@ -23,6 +23,8 @@ generate.generate_context = generate_context_wrapper
 from cookiecutter import cli
 from cookiecutter import main as api_main  # noqa: F401 referenced by tests
 
+from ccds.version import __version__
+
 
 def default_ccds_main(f):
     """Set the default for the cookiecutter template argument to the CCDS template."""
@@ -31,6 +33,9 @@ def default_ccds_main(f):
         f.params[1].default = (
             "https://github.com/drivendataorg/cookiecutter-data-science"
         )
+        # The fifth parameter is the "checkout" option in the cookiecutter cli
+        # Per #389, set this to the currently released version by default
+        f.params[4].default = __version__
         return f(*args, **kwargs)
 
     return _main

--- a/ccds/__main__.py
+++ b/ccds/__main__.py
@@ -33,9 +33,11 @@ def default_ccds_main(f):
         f.params[1].default = (
             "https://github.com/drivendataorg/cookiecutter-data-science"
         )
-        # The fifth parameter is the "checkout" option in the cookiecutter cli
+        # Find the "checkout" option in the cookiecutter cli (currently the fifth)
         # Per #389, set this to the currently released version by default
-        f.params[4].default = __version__
+        param_names = [p.name for p in f.params]
+        checkout_index = param_names.index("checkout")
+        f.params[checkout_index].default = __version__
         return f(*args, **kwargs)
 
     return _main

--- a/ccds/version.py
+++ b/ccds/version.py
@@ -1,0 +1,9 @@
+import sys
+
+if sys.version_info[:2] >= (3, 8):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
+
+
+__version__ = importlib_metadata.version(__name__.split(".", 1)[0])

--- a/ccds/version.py
+++ b/ccds/version.py
@@ -6,4 +6,4 @@ else:
     import importlib_metadata
 
 
-__version__ = importlib_metadata.version(__name__.split(".", 1)[0])
+__version__ = importlib_metadata.version("cookiecutter-data-science")

--- a/docs/docs/all-options.md
+++ b/docs/docs/all-options.md
@@ -4,3 +4,11 @@ CCDS provides a number of choices that you can use to customize your project. Th
 
 
 <!-- configuration-table.py output -->
+
+## Checking out other branches / using unreleased changes to the template
+
+By default, `ccds` will download the most recently _released_ version of the template. If there are any _unreleased_ changes to the template (or changes in a separate branch) that you want to incorporate, you can do so by checking out whatever branch you'd like to use (checkout `master` for the latest changes):
+
+```bash
+ccds -c master
+```

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,4 +1,0 @@
-# Functions here run before the project is generated.
-
-# For the use of these hooks, see
-# See https://cookiecutter.readthedocs.io/en/1.7.2/advanced/hooks.html

--- a/hooks/pre_prompt.py
+++ b/hooks/pre_prompt.py
@@ -1,0 +1,14 @@
+import warnings
+
+from ccds.version import __version__ as version
+
+
+if __name__ == "__main__":
+    if version <= "2.0.0":
+        warnings.warn(
+            DeprecationWarning(
+                "It looks like you're using a version of CCDS that "
+                "always uses the latest template. For more stable behavior, "
+                "update to a newer version of CCDS."
+            )
+        )

--- a/hooks/pre_prompt.py
+++ b/hooks/pre_prompt.py
@@ -5,9 +5,9 @@ from ccds.version import __version__ as version
 if __name__ == "__main__":
     if version < "2.0.1":
         warnings.warn(
-            "It looks like you're using a version of CCDS that "
-            "defaults to using the latest template. For more stable behavior, "
-            "update to CCDS version 2.0.1 or later. To upgrade to the latest "
-            "version, run 'pip install -U cookiecutter-data-science'",
+            "You're currently using a CCDS version that always applies the "
+            "newest template. For more stable behavior, upgrade to "
+            "CCDS version 2.0.1 or later with your package manager. "
+            "For example, with pip, run: pip install -U cookiecutter-data-science.",
             DeprecationWarning,
         )

--- a/hooks/pre_prompt.py
+++ b/hooks/pre_prompt.py
@@ -3,10 +3,11 @@ import warnings
 from ccds.version import __version__ as version
 
 if __name__ == "__main__":
-    if version <= "2.0.0":
+    if version < "2.0.1":
         warnings.warn(
             "It looks like you're using a version of CCDS that "
-            "always uses the latest template. For more stable behavior, "
-            "update to a newer version of CCDS.",
+            "defaults to using the latest template. For more stable behavior, "
+            "update to CCDS version 2.0.1 or later. To upgrade to the latest "
+            "version, run 'pip install -U cookiecutter-data-science'",
             DeprecationWarning,
         )

--- a/hooks/pre_prompt.py
+++ b/hooks/pre_prompt.py
@@ -2,13 +2,11 @@ import warnings
 
 from ccds.version import __version__ as version
 
-
 if __name__ == "__main__":
     if version <= "2.0.0":
         warnings.warn(
-            DeprecationWarning(
-                "It looks like you're using a version of CCDS that "
-                "always uses the latest template. For more stable behavior, "
-                "update to a newer version of CCDS."
-            )
+            "It looks like you're using a version of CCDS that "
+            "always uses the latest template. For more stable behavior, "
+            "update to a newer version of CCDS.",
+            DeprecationWarning,
         )


### PR DESCRIPTION
closes #317 
closes #389 

## Add GitHub actions to publish on release

~**Do not merge** - [#315](https://github.com/drivendata/cookiecutter-data-science/issues/315) is needed first. After transfer, the repo should automatically have access to the PyPI secrets needed by `release.yml`~

### `ccds.__version__`

Users can now see the version of `ccds` after importing (`ccds.__version__`). However, the *project* name is different than the *module* name. This means that in `version.py`, we have to hard code the project name with:

```python
__version__ = importlib_metadata.version("cookiecutter-data-science")
```

Instead of using:

```python
__version__ = importlib_metadata.version(__name__.split(".", 1)[0])
```

### Using release version as default tag for checkout

Per #389, we wanted a way to allow more stable behavior when someone installs ccds. Currently, any change to the template on the master branch will automatically get propagated when someone runs ccds (unless the person has downloaded the template already and opts to skip that step). As part of this PR, we now default to ccds checking out the tag associated with the installed ccds version. 

Users can always get the latest by checking out the master branch (`-c master`) or updating ccds.

### Docs

This PR does not include versioning for docs (eg. with a "Build docs" job). That is tracked separately in #334 