### PR TITLE
Fix links throughout that reference old github user to reference new github org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 _A logical, reasonably standardized but flexible project structure for doing and sharing data science work._
 
-**Cookiecutter Data Science (CCDS)** is a tool for setting up a data science project template that incorporates best practices. To learn more about CCDS's philosophy, visit the project homepage](https://drivendata.github.io/cookiecutter-data-science/).
+**Cookiecutter Data Science (CCDS)** is a tool for setting up a data science project template that incorporates best practices. To learn more about CCDS's philosophy, visit the project homepage](https://cookiecutter-data-science.drivendata.org/).
 
 > ℹ️ Cookiecutter Data Science v2 has changed from v1. It now requires installing the new cookiecutter-data-science Python package, which extends the functionality of the [cookiecutter](https://cookiecutter.readthedocs.io/en/stable/README.html) templating utility. Use the provided `ccds` command-line program instead of `cookiecutter`.
 
@@ -28,8 +28,6 @@ To start a new project, run:
 ```bash
 ccds
 ```
-
-[![asciicast](https://asciinema.org/a/244658.svg)](https://asciinema.org/a/244658)
 
 ### The resulting directory structure
 
@@ -90,14 +88,14 @@ The directory structure of your new project will look something like this (depen
 If you want to use the old v1 project template, you need to have either the cookiecutter-data-science package or cookiecutter package installed. Then, use either command-line program with the `-c v1` option:
 
 ```bash
-ccds https://github.com/drivendata/cookiecutter-data-science -c v1
+ccds https://github.com/drivendataorg/cookiecutter-data-science -c v1
 # or equivalently
-cookiecutter https://github.com/drivendata/cookiecutter-data-science -c v1
+cookiecutter https://github.com/drivendataorg/cookiecutter-data-science -c v1
 ```
 
 ## Contributing
 
-We welcome contributions! [See the docs for guidelines](https://drivendata.github.io/cookiecutter-data-science/#contributing).
+We welcome contributions! [See the docs for guidelines](https://cookiecutter-data-science.drivendata.org/contributing/).
 
 ### Installing development requirements
 

--- a/ccds/__main__.py
+++ b/ccds/__main__.py
@@ -28,7 +28,9 @@ def default_ccds_main(f):
     """Set the default for the cookiecutter template argument to the CCDS template."""
 
     def _main(*args, **kwargs):
-        f.params[1].default = "https://github.com/drivendataorg/cookiecutter-data-science"
+        f.params[1].default = (
+            "https://github.com/drivendataorg/cookiecutter-data-science"
+        )
         return f(*args, **kwargs)
 
     return _main

--- a/ccds/__main__.py
+++ b/ccds/__main__.py
@@ -28,7 +28,7 @@ def default_ccds_main(f):
     """Set the default for the cookiecutter template argument to the CCDS template."""
 
     def _main(*args, **kwargs):
-        f.params[1].default = "https://github.com/drivendata/cookiecutter-data-science"
+        f.params[1].default = "https://github.com/drivendataorg/cookiecutter-data-science"
         return f(*args, **kwargs)
 
     return _main

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -1,5 +1,5 @@
 # Contributing
 
-The Cookiecutter Data Science project is opinionated, but not afraid to be wrong. Best practices change, tools evolve, and lessons are learned. **The goal of this project is to make it easier to start, structure, and share an analysis.** [Pull requests](https://github.com/drivendata/cookiecutter-data-science/pulls) and [filing issues](https://github.com/drivendata/cookiecutter-data-science/issues) is encouraged. We'd love to hear what works for you, and what doesn't.
+The Cookiecutter Data Science project is opinionated, but not afraid to be wrong. Best practices change, tools evolve, and lessons are learned. **The goal of this project is to make it easier to start, structure, and share an analysis.** [Pull requests](https://github.com/drivendataorg/cookiecutter-data-science/pulls) and [filing issues](https://github.com/drivendataorg/cookiecutter-data-science/issues) is encouraged. We'd love to hear what works for you, and what doesn't.
 
 If you use the Cookiecutter Data Science project, link back to this page or [give us a holler](https://twitter.com/drivendataorg) and [let us know](mailto:info@drivendata.org)!

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -48,7 +48,7 @@ Cookiecutter Data Science v2 requires Python 3.8+. Since this is a cross-project
     pip install cookiecutter
 
     # From the parent directory where you want your project
-    cookiecutter https://github.com/drivendata/cookiecutter-data-science -c v1
+    cookiecutter https://github.com/drivendataorg/cookiecutter-data-science -c v1
     ```
 
 !!! info "Use the ccds command-line tool"

--- a/docs/docs/v1.md
+++ b/docs/docs/v1.md
@@ -12,7 +12,7 @@ While v1 has been deprecated and we recommend using [v2](index.md) moving forwar
 Starting a new project is as easy as running this command at the command line. No need to create a directory first, the cookiecutter will do it for you.
 
 ```nohighlight
-cookiecutter https://github.com/drivendata/cookiecutter-data-science
+cookiecutter https://github.com/drivendataorg/cookiecutter-data-science
 ```
 
 ## Example

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Cookiecutter Data Science
 site_description: A project template and directory structure for Python data science projects.
 site_url: https://cookiecutter-data-science.drivendata.org
-repo_url: https://github.com/drivendata/cookiecutter-data-science
+repo_url: https://github.com/drivendataorg/cookiecutter-data-science
 edit_uri: edit/master/docs/docs
 copyright: Project maintained by the friendly folks at <a target=_blanks href="https://www.drivendata.org">DrivenData</a>.
 theme: 

--- a/docs/scripts/generate-termynal.py
+++ b/docs/scripts/generate-termynal.py
@@ -130,7 +130,7 @@ def render_termynal():
 
     # replace local directory in ccds call with URL so it can be used for documentation
     output = output.replace(
-        str(CCDS_ROOT), "https://github.com/drivendata/cookiecutter-data-science"
+        str(CCDS_ROOT), "https://github.com/drivendataorg/cookiecutter-data-science"
     )
     return output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 ccds = "ccds.__main__:main"
 
 [project.urls]
-"Homepage" = "https://drivendata.github.io/cookiecutter-data-science/"
-"Source Code" = "https://github.com/drivendata/cookiecutter-data-science/"
-"Bug Tracker" = "https://github.com/drivendata/cookiecutter-data-science/issues"
+"Homepage" = "https://cookiecutter-data-science.drivendata.org/"
+"Source Code" = "https://github.com/drivendataorg/cookiecutter-data-science/"
+"Bug Tracker" = "https://github.com/drivendataorg/cookiecutter-data-science/issues"
 "DrivenData" = "https://drivendata.co"


### PR DESCRIPTION
This PR updates links throughout the project to reflect updated ownership of the repo by the `drivendataorg` rather than the legacy `drivendata` user.