### PR TITLE
Remove config import from init to fix scaffold usage

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,9 @@
+# cookiecutter-data-science Changelog
+
+## UNRELEASED
+
+- Fixes issue with scaffold code that import of config did not work. Adds testing of imports to test suite. (Issue [#370](https://github.com/drivendataorg/cookiecutter-data-science/issues/370))
+
+## v2.0.0 (2024-05-22)
+
+- Released version 2.0.0! :tada: See [docs](https://cookiecutter-data-science.drivendata.org/) and [announcement blog post](https://drivendata.co/blog/ccds-v2) for more information.

--- a/ccds/__main__.py
+++ b/ccds/__main__.py
@@ -28,9 +28,9 @@ def default_ccds_main(f):
     """Set the default for the cookiecutter template argument to the CCDS template."""
 
     def _main(*args, **kwargs):
-        f.params[
-            1
-        ].default = "https://github.com/drivendataorg/cookiecutter-data-science"
+        f.params[1].default = (
+            "https://github.com/drivendataorg/cookiecutter-data-science"
+        )
         return f(*args, **kwargs)
 
     return _main

--- a/ccds/__main__.py
+++ b/ccds/__main__.py
@@ -28,9 +28,9 @@ def default_ccds_main(f):
     """Set the default for the cookiecutter template argument to the CCDS template."""
 
     def _main(*args, **kwargs):
-        f.params[1].default = (
-            "https://github.com/drivendataorg/cookiecutter-data-science"
-        )
+        f.params[
+            1
+        ].default = "https://github.com/drivendataorg/cookiecutter-data-science"
         return f(*args, **kwargs)
 
     return _main

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -76,4 +76,7 @@ for generated_path in Path("{{ cookiecutter.module_name }}").iterdir():
         shutil.rmtree(generated_path)
     elif generated_path.name != "__init__.py":
         generated_path.unlink()
+    elif generated_path.name == "__init__.py":
+        # remove any content in __init__.py since it won't be available
+        generated_path.write_text("")
 # {% endif %}

--- a/tests/conda_harness.sh
+++ b/tests/conda_harness.sh
@@ -6,6 +6,7 @@ eval "$(conda shell.bash hook)"
 
 PROJECT_NAME=$(basename $1)
 CCDS_ROOT=$(dirname $0)
+MODULE_NAME=$2
 
 # configure exit / teardown behavior
 function finish {
@@ -34,4 +35,4 @@ make create_environment
 conda activate $PROJECT_NAME
 make requirements
 
-run_tests $PROJECT_NAME
+run_tests $PROJECT_NAME $MODULE_NAME

--- a/tests/pipenv_harness.sh
+++ b/tests/pipenv_harness.sh
@@ -3,6 +3,7 @@ set -ex
 
 PROJECT_NAME=$(basename $1)
 CCDS_ROOT=$(dirname $0)
+MODULE_NAME=$2
 
 # configure exit / teardown behavior
 function finish {
@@ -27,3 +28,11 @@ make requirements
 
 # test with pipenv run
 pipenv run python -c "import sys; assert \"$PROJECT_NAME\" in sys.executable"
+
+# test importable
+pipenv run python -c "import $MODULE_NAME"
+
+# test config importable if scaffolded
+if [ -f "$MODULE_NAME/config.py" ]; then
+    pipenv run python -c "from $MODULE_NAME import config"
+fi

--- a/tests/test_functions.sh
+++ b/tests/test_functions.sh
@@ -9,4 +9,11 @@ function run_tests () {
         exit 99
     fi
 
+    # test importable
+    python -c "import $2"
+
+    # test config importable if scaffolded
+    if [ -f "$2/config.py" ]; then
+        python -c "from $2 import config"
+    fi
 }

--- a/tests/virtualenv_harness.sh
+++ b/tests/virtualenv_harness.sh
@@ -3,6 +3,7 @@ set -e
 
 PROJECT_NAME=$(basename $1)
 CCDS_ROOT=$(dirname $0)
+MODULE_NAME=$2
 
 # configure exit / teardown behavior
 function finish {
@@ -55,4 +56,5 @@ fi
 
 make requirements
 
-run_tests $PROJECT_NAME
+run_tests $PROJECT_NAME $MODULE_NAME
+

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/__init__.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/__init__.py
@@ -1,0 +1,1 @@
+from {{ cookiecutter.module_name }} import config  # noqa: F401

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/__init__.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/__init__.py
@@ -1,1 +1,0 @@
-import config  # noqa: F401


### PR DESCRIPTION
 - Remove config import from `__init__.py` (not needed and also breaks since it is there in non-scaffold scenario)
 - Refactor some repeated code
 - Add import and import config tests
 - Add changelog


Closes #370 