### PR TITLE
Add ruff as default linting + formatting option

### DIFF
--- a/ccds-help.json
+++ b/ccds-help.json
@@ -203,6 +203,29 @@
         ]
     },
     {
+        "field": "linting_and_formatting",
+        "help": {
+            "description": "How to handle linting and formatting on your code.",
+            "more_information": ""
+        },
+        "choices": [
+            {
+                "choice": "ruff",
+                "help": {
+                    "description": "Use ruff for linting and formatting.",
+                    "more_information": ""
+                } 
+            },
+            {
+                "choice": "flake8+black+isort",
+                "help": {
+                    "description": "Use flake8 for linting and black+isort for formatting.",
+                    "more_information": ""
+                } 
+            }
+        ]
+    },
+    {
         "field": "open_source_license",
         "help": {
             "description": "Whether to include a license file and which one to use.",

--- a/ccds.json
+++ b/ccds.json
@@ -26,6 +26,10 @@
         "none",
         "basic"
     ],
+    "linting_and_formatting": [
+        "ruff",
+        "flake8+black+isort"
+    ],
     "open_source_license": ["No license file", "MIT", "BSD-3-Clause"],
     "docs": ["mkdocs", "none"],
     "include_code_scaffold": ["Yes", "No"]

--- a/ccds/hook_utils/dependencies.py
+++ b/ccds/hook_utils/dependencies.py
@@ -1,10 +1,15 @@
 packages = [
-    "black",
-    "flake8",
-    "isort",
     "pip",
     "python-dotenv",
 ]
+
+flake8_black_isort = [
+    "black",
+    "flake8",
+    "isort",
+]
+
+ruff = ["ruff"]
 
 basic = [
     "ipython",

--- a/docs/scripts/generate-termynal.py
+++ b/docs/scripts/generate-termynal.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 from pathlib import Path
 
@@ -49,14 +50,16 @@ ccds_script = [
     ("author_name", "Dat A. Scientist"),
     ("description", "This is my analysis of the data."),
     ("python_version_number", "3.12"),
-    ("Choose from", "3"),
+    ("Choose from", "3"),  # dataset_storage
     ("bucket", "s3://my-aws-bucket"),
     ("aws_profile", ""),
-    ("Choose from", "2"),
-    ("Choose from", "1"),
-    ("Choose from", "2"),
-    ("Choose from", "2"),
-    ("Choose from", "1"),
+    ("Choose from", "2"),  # environment_manager
+    ("Choose from", "1"),  # dependency_file
+    ("Choose from", "2"),  # pydata_packages
+    ("Choose from", "1"),  # linting_and_formatting
+    ("Choose from", "2"),  # open_source_license
+    ("Choose from", "1"),  # docs
+    ("Choose from", "2"),  # include_code_scaffold
 ]
 
 
@@ -127,6 +130,11 @@ def render_termynal():
 
     html_lines.append("</div>")
     output = "\n".join(html_lines)
+
+    # Ensure that all options are contained in the output
+    options = json.load((CCDS_ROOT / "ccds.json").open("r")).keys()
+    for option in options:
+        assert option in output, f'Option "{option}" not found in termynal output.'
 
     # replace local directory in ccds call with URL so it can be used for documentation
     output = output.replace(

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -5,7 +5,14 @@ from pathlib import Path
 # https://github.com/cookiecutter/cookiecutter/issues/824
 #   our workaround is to include these utility functions in the CCDS package
 from ccds.hook_utils.custom_config import write_custom_config
-from ccds.hook_utils.dependencies import basic, packages, scaffold, write_dependencies
+from ccds.hook_utils.dependencies import (
+    basic,
+    flake8_black_isort,
+    packages,
+    ruff,
+    scaffold,
+    write_dependencies,
+)
 
 #
 #  TEMPLATIZED VARIABLES FILLED IN BY COOKIECUTTER
@@ -24,6 +31,13 @@ packages_to_install += scaffold
 packages_to_install += basic
 # {% endif %}
 
+# {% if cookiecutter.linting_and_formatting == "ruff" %}
+packages_to_install += ruff
+# Remove setup.cfg
+Path("setup.cfg").unlink()
+# {% elif cookiecutter.linting_and_formatting == "flake8+black+isort" %}
+packages_to_install += flake8_black_isort
+# {% endif %}
 # track packages that are not available through conda
 pip_only_packages = [
     "awscli",

--- a/tests/conda_harness.sh
+++ b/tests/conda_harness.sh
@@ -34,5 +34,7 @@ make
 make create_environment
 conda activate $PROJECT_NAME
 make requirements
+make lint
+make format
 
 run_tests $PROJECT_NAME $MODULE_NAME

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,7 @@ def config_generator(fast=False):
         "dataset_storage",
         "open_source_license",
         "include_code_scaffold",
+        "linting_and_formatting",
         "docs",
     ]
     cyclers = {k: cycle(cookiecutter_json[k]) for k in cycle_fields}

--- a/tests/pipenv_harness.sh
+++ b/tests/pipenv_harness.sh
@@ -26,6 +26,10 @@ make create_environment
 # can happen outside of environment since pipenv knows based on Pipfile
 make requirements
 
+# linting + formatting must happen inside environment
+pipenv run make lint
+pipenv run make format
+
 # test with pipenv run
 pipenv run python -c "import sys; assert \"$PROJECT_NAME\" in sys.executable"
 

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -49,8 +49,6 @@ def test_baking_configs(config, fast):
     with bake_project(config) as project_directory:
         verify_folders(project_directory, config)
         verify_files(project_directory, config)
-        lint(project_directory)
-        format(project_directory)
 
         if fast < 2:
             verify_makefile_commands(project_directory, config)
@@ -159,6 +157,8 @@ def verify_makefile_commands(root, config):
     - blank command listing commands
     - create_environment
     - requirements
+    - linting
+    - formatting
     Ensure that these use the proper environment.
     """
     test_path = Path(__file__).parent
@@ -187,35 +187,18 @@ def verify_makefile_commands(root, config):
         stdout=PIPE,
     )
 
-    stdout_output, _ = _decode_print_stdout_stderr(result)
+    stdout_output, stderr_output = _decode_print_stdout_stderr(result)
 
     # Check that makefile help ran successfully
     assert "Available rules:" in stdout_output
     assert "clean                    Delete all compiled Python files" in stdout_output
 
-    assert result.returncode == 0
-
-
-def lint(root):
-    """Run the linters on the project."""
-    result = run(
-        ["make", "lint"],
-        cwd=root,
-        stderr=PIPE,
-        stdout=PIPE,
-    )
-    _, _ = _decode_print_stdout_stderr(result)
-
-    assert result.returncode == 0
-
-def format(root):
-    """Run the linters on the project."""
-    result = run(
-        ["make", "format"],
-        cwd=root,
-        stderr=PIPE,
-        stdout=PIPE,
-    )
-    _, _ = _decode_print_stdout_stderr(result)
+    # Check that linting and formatting ran successfully
+    if config["linting_and_formatting"] == "ruff":
+        assert "All checks passed!" in stdout_output
+        assert "reformatted" not in stdout_output
+    elif config["linting_and_formatting"] == "flake8+black+isort":
+        assert "All done!" in stderr_output
+        assert "reformatted" not in stderr_output
 
     assert result.returncode == 0

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -196,9 +196,11 @@ def verify_makefile_commands(root, config):
     # Check that linting and formatting ran successfully
     if config["linting_and_formatting"] == "ruff":
         assert "All checks passed!" in stdout_output
+        assert "left unchanged" in stdout_output
         assert "reformatted" not in stdout_output
     elif config["linting_and_formatting"] == "flake8+black+isort":
         assert "All done!" in stderr_output
+        assert "left unchanged" in stderr_output
         assert "reformatted" not in stderr_output
 
     assert result.returncode == 0

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -50,6 +50,7 @@ def test_baking_configs(config, fast):
         verify_folders(project_directory, config)
         verify_files(project_directory, config)
         lint(project_directory)
+        format(project_directory)
 
         if fast < 2:
             verify_makefile_commands(project_directory, config)
@@ -100,7 +101,6 @@ def verify_files(root, config):
         "Makefile",
         "README.md",
         "pyproject.toml",
-        "setup.cfg",
         ".env",
         ".gitignore",
         "data/external/.gitkeep",
@@ -119,6 +119,9 @@ def verify_files(root, config):
     # conditional files
     if not config["open_source_license"].startswith("No license"):
         expected_files.append("LICENSE")
+
+    if config["linting_and_formatting"] == "flake8+black+isort":
+        expected_files.append("setup.cfg")
 
     if config["include_code_scaffold"] == "Yes":
         expected_files += [
@@ -197,6 +200,18 @@ def lint(root):
     """Run the linters on the project."""
     result = run(
         ["make", "lint"],
+        cwd=root,
+        stderr=PIPE,
+        stdout=PIPE,
+    )
+    _, _ = _decode_print_stdout_stderr(result)
+
+    assert result.returncode == 0
+
+def format(root):
+    """Run the linters on the project."""
+    result = run(
+        ["make", "format"],
         cwd=root,
         stderr=PIPE,
         stdout=PIPE,

--- a/tests/virtualenv_harness.sh
+++ b/tests/virtualenv_harness.sh
@@ -55,6 +55,8 @@ else
 fi
 
 make requirements
+make lint
+make format
 
 run_tests $PROJECT_NAME $MODULE_NAME
 

--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -8,7 +8,7 @@
 *.swp
 *.swo
 
-## https://github.com/github/gitignore/blob/4488915eec0b3a45b5c63ead28f286819c0917de/Python.gitignore
+## https://github.com/github/gitignore/blob/e8554d85bf62e38d6db966a50d2064ac025fd82a/Python.gitignore
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -106,6 +106,12 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
@@ -118,8 +124,10 @@ ipython_config.py
 #pdm.lock
 #   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
 #   in version control.
-#   https://pdm.fming.dev/#use-with-ide
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
 .pdm.toml
+.pdm-python
+.pdm-build/
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
@@ -170,3 +178,9 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -35,6 +35,7 @@ clean:
 ## Lint using ruff (use `make format` to do formatting)
 .PHONY: lint
 lint:
+	ruff format --check
 	ruff check
 
 ## Format source code with ruff

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -35,13 +35,13 @@ clean:
 ## Lint using ruff (use `make format` to do formatting)
 .PHONY: lint
 lint:
-	ruff check {{ cookiecutter.module_name }}
+	ruff check
 
 ## Format source code with ruff
 .PHONY: format
 format:
-	ruff check --fix {{ cookiecutter.module_name }}
-	ruff format {{ cookiecutter.module_name }}
+	ruff check --fix
+	ruff format
 {% elif cookiecutter.linting_and_formatting == 'flake8+black+isort' %}
 ## Lint using flake8, black, and isort (use `make format` to do formatting)
 .PHONY: lint

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -40,21 +40,22 @@ lint:
 ## Format source code with ruff
 .PHONY: format
 format:
-	ruff check --select I --fix {{ cookiecutter.module_name }}
+	ruff check --fix {{ cookiecutter.module_name }}
 	ruff format {{ cookiecutter.module_name }}
 {% elif cookiecutter.linting_and_formatting == 'flake8+black+isort' %}
 ## Lint using flake8, black, and isort (use `make format` to do formatting)
 .PHONY: lint
 lint:
 	flake8 {{ cookiecutter.module_name }}
-	isort --check --diff --profile black {{ cookiecutter.module_name }}
-	black --check --config pyproject.toml {{ cookiecutter.module_name }}
+	isort --check --diff {{ cookiecutter.module_name }}
+	black --check --verbose {{ cookiecutter.module_name }}
 
 ## Format source code with black
 .PHONY: format
 format:
-	isort --profile black {{ cookiecutter.module_name }}
-	black --config pyproject.toml {{ cookiecutter.module_name }}
+	isort {{ cookiecutter.module_name }}
+	black --verbose {{ cookiecutter.module_name }}
+	exit -1
 {% endif %}
 
 {% if not cookiecutter.dataset_storage.none %}

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -48,14 +48,13 @@ format:
 lint:
 	flake8 {{ cookiecutter.module_name }}
 	isort --check --diff {{ cookiecutter.module_name }}
-	black --check --verbose {{ cookiecutter.module_name }}
+	black --check {{ cookiecutter.module_name }}
 
 ## Format source code with black
 .PHONY: format
 format:
 	isort {{ cookiecutter.module_name }}
-	black --verbose {{ cookiecutter.module_name }}
-	exit -1
+	black {{ cookiecutter.module_name }}
 {% endif %}
 
 {% if not cookiecutter.dataset_storage.none %}

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -11,7 +11,7 @@ PYTHON_INTERPRETER = python
 #################################################################################
 
 {% if cookiecutter.dependency_file != 'none' %}
-## Install Python Dependencies
+## Install Python dependencies
 .PHONY: requirements
 requirements:
 	{% if "requirements.txt" == cookiecutter.dependency_file -%}
@@ -31,7 +31,19 @@ clean:
 	find . -type f -name "*.py[co]" -delete
 	find . -type d -name "__pycache__" -delete
 
-## Lint using flake8 and black (use `make format` to do formatting)
+{% if cookiecutter.linting_and_formatting == 'ruff' %}
+## Lint using ruff (use `make format` to do formatting)
+.PHONY: lint
+lint:
+	ruff check {{ cookiecutter.module_name }}
+
+## Format source code with ruff
+.PHONY: format
+format:
+	ruff check --select I --fix {{ cookiecutter.module_name }}
+	ruff format {{ cookiecutter.module_name }}
+{% elif cookiecutter.linting_and_formatting == 'flake8+black+isort' %}
+## Lint using flake8, black, and isort (use `make format` to do formatting)
 .PHONY: lint
 lint:
 	flake8 {{ cookiecutter.module_name }}
@@ -41,7 +53,9 @@ lint:
 ## Format source code with black
 .PHONY: format
 format:
+	isort --profile black {{ cookiecutter.module_name }}
 	black --config pyproject.toml {{ cookiecutter.module_name }}
+{% endif %}
 
 {% if not cookiecutter.dataset_storage.none %}
 ## Download Data from storage system
@@ -72,7 +86,7 @@ sync_data_up:
 {% endif %}
 
 {% if cookiecutter.environment_manager != 'none' %}
-## Set up python interpreter environment
+## Set up Python interpreter environment
 .PHONY: create_environment
 create_environment:
 	{% if cookiecutter.environment_manager == 'conda' -%}
@@ -97,7 +111,7 @@ create_environment:
 #################################################################################
 
 {% if cookiecutter.include_code_scaffold == 'Yes' %}
-## Make Dataset
+## Make dataset
 .PHONY: data
 data: requirements
 	$(PYTHON_INTERPRETER) {{ cookiecutter.module_name }}/dataset.py

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -34,4 +34,8 @@ profile = "black"
 [tool.ruff]
 line-length = 99
 src = ["{{ cookiecutter.module_name }}"]
+include = ["pyproject.toml", "{{ cookiecutter.module_name }}/**/*.py"]
+
+[tool.ruff.lint]
+extend-select = ["I"]  # Add import sorting
 {% endif %}

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     {% if cookiecutter.open_source_license == 'MIT' %}"License :: OSI Approved :: MIT License"{% elif cookiecutter.open_source_license == 'BSD-3-Clause' %}"License :: OSI Approved :: BSD License"{% endif %}
 ]
 requires-python = "~={{ cookiecutter.python_version_number }}"
-
 {% if cookiecutter.linting_and_formatting == 'flake8+black+isort' %}
 [tool.black]
 line-length = 99
@@ -26,10 +25,10 @@ exclude = '''
     \.git
   | \.venv
 )/
+'''
 
 [tool.isort]
 profile = "black"
-'''
 {% endif %}
 {% if cookiecutter.linting_and_formatting == 'ruff' %}
 [tool.ruff]

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 ]
 requires-python = "~={{ cookiecutter.python_version_number }}"
 
+{% if cookiecutter.linting_and_formatting == 'flake8+black+isort' %}
 [tool.black]
 line-length = 99
 include = '\.pyi?$'
@@ -25,8 +26,13 @@ exclude = '''
     \.git
   | \.venv
 )/
-'''
 
-[tool.ruff.lint.isort]
-known_first_party = ["{{ cookiecutter.module_name }}"]
-force_sort_within_sections = true
+[tool.isort]
+profile = "black"
+'''
+{% endif %}
+{% if cookiecutter.linting_and_formatting == 'ruff' %}
+[tool.ruff]
+line-length = 99
+src = ["{{ cookiecutter.module_name }}"]
+{% endif %}


### PR DESCRIPTION
Closes #374
Closes #388 

This PR adds [ruff](https://docs.astral.sh/ruff/) as the default linting and formatting option for new ccds projects.

## Implementation notes

* I've slightly altered the Makefile command tests so that they now run within each venv harness. I check to ensure that linting and formatting run without error and that nothing is reformatted.
  * For whatever reason, I found that ruff piped to stdout and flake8/black/isort piped to stderr. Maybe there's a nuance here or I've done something wrong?
* I've cleaned up the generated `pyproject.toml` and removed `setup.cfg` if using ruff since it's no longer needed. 
* I didn't stray very far from the default ruff config, changing only the line length. If we are opinionated about the default set of linting / formatting options, happy to add those, but I have no strong preferences.

## Discussion

As mentioned, this PR makes ruff the default option. I think there's good arguments for this that mostly boil down to "it's simpler + faster":

* one tool for linting + formatting so fewer dependencies and simpler config
* no `setup.cfg` file so everything can live in `pyproject.toml`
* ruff is [quite fast](https://docs.astral.sh/ruff/)

However, ruff is still (relatively) new, whereas flake8/black/isort is more mature, and most projects won't notice the speed difference until they get quite large. I could be persuaded that we should introduce ruff without making it the default option.