### PR TITLE
394 makefile fixes

### DIFF
--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -48,7 +48,7 @@ format:
 .PHONY: sync_data_down
 sync_data_down:
 	{% if cookiecutter.dataset_storage.s3 -%}
-	aws s3 sync s3://{{ cookiecutter.dataset_storage.s3.bucket }}/data/\
+	aws s3 sync s3://{{ cookiecutter.dataset_storage.s3.bucket }}/data/ \
 		data/ {% if cookiecutter.dataset_storage.s3.aws_profile != 'default' %} --profile {{ cookiecutter.dataset_storage.s3.aws_profile }}{% endif %}
 	{% elif cookiecutter.dataset_storage.azure -%}
 	az storage blob download-batch -s {{ cookiecutter.dataset_storage.azure.container }}/data/ \
@@ -61,8 +61,8 @@ sync_data_down:
 .PHONY: sync_data_up
 sync_data_up:
 	{% if cookiecutter.dataset_storage.s3 -%}
-	aws s3 sync s3://{{ cookiecutter.dataset_storage.s3.bucket }}/data/ data/\
-		{% if cookiecutter.dataset_storage.s3.aws_profile %} --profile $(PROFILE){% endif %}
+	aws s3 sync data/ \
+		s3://{{ cookiecutter.dataset_storage.s3.bucket }}/data {% if cookiecutter.dataset_storage.s3.aws_profile != 'default' %} --profile {{ cookiecutter.dataset_storage.s3.aws_profile }}{% endif %}
 	{% elif cookiecutter.dataset_storage.azure -%}
 	az storage blob upload-batch -d {{ cookiecutter.dataset_storage.azure.container }}/data/ \
 		-s data/

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -100,7 +100,7 @@ create_environment:
 ## Make Dataset
 .PHONY: data
 data: requirements
-	$(PYTHON_INTERPRETER) {{ cookiecutter.module_name }}/data/make_dataset.py
+	$(PYTHON_INTERPRETER) {{ cookiecutter.module_name }}/dataset.py
 {% endif %}
 
 #################################################################################


### PR DESCRIPTION
A few tweaks to Makefile commands

 - Added whitespace to `sync_data_down`
 - Swapped order for `sync_data_up`
 - Fix conditional profile logic in `sync_data_up` (so it matches `sync_data_down`)
 - Fix path for `make data`

Closes #394 


Tested manually:

```
❯ ccds .
project_name (project_name):
repo_name (project_name):
module_name (project_name):
author_name (Your name (or your organization/company/team)):
description (A short description of the project.):
python_version_number (3.10):
Select dataset_storage
    1 - none
    2 - azure
    3 - s3
    4 - gcs
    Choose from [1/2/3/4] (1): 3
bucket (bucket-name): drivendata-ccds-test
aws_profile (default):
Select environment_manager
    1 - virtualenv
    2 - conda
    3 - pipenv
    4 - none
    Choose from [1/2/3/4] (1):
Select dependency_file
    1 - requirements.txt
    2 - environment.yml
    3 - Pipfile
    Choose from [1/2/3] (1):
Select pydata_packages
    1 - none
    2 - basic
    Choose from [1/2] (1):
Select open_source_license
    1 - No license file
    2 - MIT
    3 - BSD-3-Clause
    Choose from [1/2/3] (1):
Select docs
    1 - mkdocs
    2 - none
    Choose from [1/2] (1):
Select include_code_scaffold
    1 - Yes
    2 - No
    Choose from [1/2] (1):

❯ cd project_name/
❯ make sync_data_up
aws s3 sync data/ \
		s3://drivendata-ccds-test/data
upload: data/external/.gitkeep to s3://drivendata-ccds-test/data/external/.gitkeep
upload: data/processed/.gitkeep to s3://drivendata-ccds-test/data/processed/.gitkeep
upload: data/interim/.gitkeep to s3://drivendata-ccds-test/data/interim/.gitkeep
upload: data/raw/.gitkeep to s3://drivendata-ccds-test/data/raw/.gitkeep
cookiecutter-data-science/project_name on  394-makefile-fixes [$?] is 📦 v0.0.1 via 🐍 v3.12.4 on ☁️  peter@drivendata.org took 6s

❯ make sync_data_down
aws s3 sync s3://drivendata-ccds-test/data/ \
		data/

❯ make data
python project_name/dataset.py
2024-07-11 17:33:04.156 | INFO     | project_name.config:<module>:11 - PROJ_ROOT path is: /Users/bull/code/cookiecutter-data-science/project_name
2024-07-11 17:33:04.160 | INFO     | __main__:main:20 - Processing dataset...
2024-07-11 17:33:04.416 | INFO     | __main__:main:23 - Something happened for iteration 5.
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 15240.93it/s]
2024-07-11 17:33:04.417 | SUCCESS  | __main__:main:24 - Processing dataset complete.
```