### PR TITLE
Update directory tree in README template

### DIFF
--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -18,7 +18,7 @@
 │   ├── processed      <- The final, canonical data sets for modeling.
 │   └── raw            <- The original, immutable data dump.
 │
-├── docs               <- A default mkdocs project; see mkdocs.org for details
+├── docs               <- A default mkdocs project; see www.mkdocs.org for details
 │
 ├── models             <- Trained and serialized models, model predictions, or model summaries
 │
@@ -26,8 +26,8 @@
 │                         the creator's initials, and a short `-` delimited description, e.g.
 │                         `1.0-jqp-initial-data-exploration`.
 │
-├── pyproject.toml     <- Project configuration file with package metadata for {{ cookiecutter.module_name }}
-│                         and configuration for tools like black
+├── pyproject.toml     <- Project configuration file with package metadata for 
+│                         {{ cookiecutter.module_name }} and configuration for tools like black
 │
 ├── references         <- Data dictionaries, manuals, and all other explanatory materials.
 │
@@ -39,23 +39,22 @@
 │
 ├── setup.cfg          <- Configuration file for flake8
 │
-└── {{ cookiecutter.module_name }}                <- Source code for use in this project.
+└── {{ cookiecutter.module_name }}   <- Source code for use in this project.
     │
-    ├── __init__.py    <- Makes {{ cookiecutter.module_name }} a Python module
+    ├── __init__.py             <- Makes {{ cookiecutter.module_name }} a Python module
     │
-    ├── data           <- Scripts to download or generate data
-    │   └── make_dataset.py
+    ├── config.py               <- Store useful variables and configuration
     │
-    ├── features       <- Scripts to turn raw data into features for modeling
-    │   └── build_features.py
+    ├── dataset.py              <- Scripts to download or generate data
     │
-    ├── models         <- Scripts to train models and then use trained models to make
-    │   │                 predictions
-    │   ├── predict_model.py
-    │   └── train_model.py
+    ├── features.py             <- Code to create features for modeling
     │
-    └── visualization  <- Scripts to create exploratory and results oriented visualizations
-        └── visualize.py
+    ├── modeling                
+    │   ├── __init__.py 
+    │   ├── predict.py          <- Code to run model inference with trained models          
+    │   └── train.py            <- Code to train models
+    │
+    └── plots.py                <- Code to create visualizations
 ```
 
 --------


### PR DESCRIPTION
This PR fixes the directory tree in the README template.

It seems that the layout structure has changed with cookiecutter-data-science v2 thus the generated structure does not match the directory tree shown in the README.

I copy pasted the directory tree from the top-level README and pasted it into the template.