### PR TITLE
Add back isort configuration that was removed in #387

### DIFF
--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -29,6 +29,8 @@ exclude = '''
 
 [tool.isort]
 profile = "black"
+known_first_party = ["{{ cookiecutter.module_name }}"]
+force_sort_within_sections = true
 {% endif %}
 {% if cookiecutter.linting_and_formatting == 'ruff' %}
 [tool.ruff]
@@ -38,4 +40,8 @@ include = ["pyproject.toml", "{{ cookiecutter.module_name }}/**/*.py"]
 
 [tool.ruff.lint]
 extend-select = ["I"]  # Add import sorting
+
+[tool.ruff.lint.isort]
+known-first-party = ["{{ cookiecutter.module_name }}"]
+force-sort-within-sections = true
 {% endif %}

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/dataset.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/dataset.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
-import typer
 from loguru import logger
 from tqdm import tqdm
+import typer
 
 from {{ cookiecutter.module_name }}.config import PROCESSED_DATA_DIR, RAW_DATA_DIR
 

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/features.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/features.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
-import typer
 from loguru import logger
 from tqdm import tqdm
+import typer
 
 from {{ cookiecutter.module_name }}.config import PROCESSED_DATA_DIR
 

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/modeling/predict.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/modeling/predict.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
-import typer
 from loguru import logger
 from tqdm import tqdm
+import typer
 
 from {{ cookiecutter.module_name }}.config import MODELS_DIR, PROCESSED_DATA_DIR
 

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/modeling/train.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/modeling/train.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
-import typer
 from loguru import logger
 from tqdm import tqdm
+import typer
 
 from {{ cookiecutter.module_name }}.config import MODELS_DIR, PROCESSED_DATA_DIR
 

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/plots.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.module_name }}/plots.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
-import typer
 from loguru import logger
 from tqdm import tqdm
+import typer
 
 from {{ cookiecutter.module_name }}.config import FIGURES_DIR, PROCESSED_DATA_DIR
 


### PR DESCRIPTION
#387 changed our default behavior by removing configuration. This PR adds them back in. It also fixes #388 by using the correct names. 