### PR TITLE
Add option for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -f .coverage
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
-	
+
 dist: clean ## builds source and wheel package
 	python -m build
 	ls -l dist
@@ -71,7 +71,7 @@ docs-serve:
 ###     TESTS
 
 test: _prep
-	pytest -vvv --durations=0
+	pytest -vvv --durations=0 tests
 
 test-fastest: _prep
 	pytest -vvv -FFF

--- a/ccds-help.json
+++ b/ccds-help.json
@@ -217,6 +217,36 @@
         ]
     },
     {
+        "field": "testing_framework",
+        "help": {
+            "description": "Framework used for testing your code.",
+            "more_information": ""
+        },
+        "choices": [
+            {
+                "choice": "none",
+                "help": {
+                    "description": "No testing framework.",
+                    "more_information": ""
+                }
+            },
+            {
+                "choice": "pytest",
+                "help": {
+                    "description": "Use the pytest framework for testing.",
+                    "more_information": "[Docs](https://docs.pytest.org/en/latest/)"
+                }
+            },
+            {
+                "choice": "unittest",
+                "help": {
+                    "description": "Use Python's built-in testing framework.",
+                    "more_information": "[Docs](https://docs.python.org/3/library/unittest.html)"
+                }
+            }
+        ]
+    },
+    {
         "field": "linting_and_formatting",
         "help": {
             "description": "How to handle linting and formatting on your code.",

--- a/ccds.json
+++ b/ccds.json
@@ -28,6 +28,11 @@
         "none",
         "basic"
     ],
+    "testing_framework": [
+        "none",
+        "pytest",
+        "unittest"
+    ],
     "linting_and_formatting": [
         "ruff",
         "flake8+black+isort"

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -44,6 +44,27 @@ pip_only_packages = [
     "python-dotenv",
 ]
 
+# Select testing framework
+tests_path = Path("tests")
+
+# {% if cookiecutter.testing_framework == "pytest" %}
+packages_to_install += ["pytest"]
+# {% endif %}
+
+# {% if cookiecutter.testing_framework == "none" %}
+shutil.rmtree(tests_path)
+
+# {% else %}
+tests_subpath = tests_path / "{{ cookiecutter.testing_framework }}"
+for obj in tests_subpath.iterdir():
+    shutil.move(str(obj), str(tests_path))
+
+# Remove all remaining tests templates
+for tests_template in tests_path.iterdir():
+    if tests_template.is_dir() and not tests_template.name == "tests":
+        shutil.rmtree(tests_template)
+# {% endif %}
+
 # Use the selected documentation package specified in the config,
 # or none if none selected
 docs_path = Path("docs")

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -31,7 +31,7 @@ requirements:
 	conda env update --name $(PROJECT_NAME) --file environment.yml --prune
 	{% elif "Pipfile" == cookiecutter.dependency_file -%}
 	pipenv install
-	{% endif %}
+{% endif %}
 {% endif %}
 
 
@@ -67,6 +67,17 @@ format:
 	isort {{ cookiecutter.module_name }}
 	black {{ cookiecutter.module_name }}
 {% endif %}
+
+{% if cookiecutter.testing_framework != 'none' %}
+## Run tests
+.PHONY: test
+test:
+{%- if cookiecutter.testing_framework == 'unittest' %}
+	python -m unittest discover -s tests
+{%- elif cookiecutter.testing_framework == 'pytest' %}
+	python -m pytest tests
+{%- endif -%}
+{%- endif -%}
 
 {% if not cookiecutter.dataset_storage.none %}
 ## Download Data from storage system
@@ -118,7 +129,7 @@ create_environment:
 	@echo ">>> New uv virtual environment created. Activate with:"
 	@echo ">>> Windows: .\\\\.venv\\\\Scripts\\\\activate"
 	@echo ">>> Unix/macOS: source ./.venv/bin/activate"
-	{% endif %}
+{% endif %}
 {% endif %}
 
 

--- a/{{ cookiecutter.repo_name }}/tests/pytest/test_data.py
+++ b/{{ cookiecutter.repo_name }}/tests/pytest/test_data.py
@@ -1,0 +1,1 @@
+import pytest

--- a/{{ cookiecutter.repo_name }}/tests/pytest/test_data.py
+++ b/{{ cookiecutter.repo_name }}/tests/pytest/test_data.py
@@ -1,1 +1,5 @@
 import pytest
+
+
+def test_code_is_tested():
+    assert False

--- a/{{ cookiecutter.repo_name }}/tests/unittest/test_data.py
+++ b/{{ cookiecutter.repo_name }}/tests/unittest/test_data.py
@@ -1,0 +1,1 @@
+assert True

--- a/{{ cookiecutter.repo_name }}/tests/unittest/test_data.py
+++ b/{{ cookiecutter.repo_name }}/tests/unittest/test_data.py
@@ -1,1 +1,11 @@
-assert True
+import unittest
+
+
+class TestCodeIsTested(unittest.TestCase):
+
+    def test_code_is_tested(self):
+        self.assertTrue(False)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #195

- Add an option for testing with pytest, unittest, or none.

- If a testing framework is selected, add a root-level `tests` directory with one failing test that tests that the code is tested

- Add a `make test` command