### PR TITLE
Fix terminal animation generation in docs build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,12 +5,10 @@ on:
   push:
     branches: [master]
     paths-ignore: 
-      - "docs/**"
       - "README.md"
   pull_request:
     branches: [master]
     paths-ignore: 
-      - "docs/**"
       - "README.md"
   schedule:
     # Run every Sunday
@@ -41,6 +39,10 @@ jobs:
       - name: Lint
         run: |
           make lint
+
+      - name: Build documentation
+        run: |
+          make docs
 
   tests:
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python-version }})

--- a/docs/scripts/generate-termynal.py
+++ b/docs/scripts/generate-termynal.py
@@ -56,6 +56,7 @@ ccds_script = [
     ("Choose from", "2"),  # environment_manager
     ("Choose from", "1"),  # dependency_file
     ("Choose from", "2"),  # pydata_packages
+    ("Choose from", "3"),  # testing_framework
     ("Choose from", "1"),  # linting_and_formatting
     ("Choose from", "2"),  # open_source_license
     ("Choose from", "1"),  # docs


### PR DESCRIPTION
When we added testing frameworks to the option set (#447) we did not update the terminal animation inputs so the last one was missing. This made the build fail because we `assert` that all options are present in the generated animation.

To prevent us missing this in the future, I've added building the docs to the `tests` workflow so that we'll fail if the docs do not properly generate.