### PR TITLE
Add community forks documentation page and mkdocs link

### DIFF
--- a/docs/community-forks.md
+++ b/docs/community-forks.md
@@ -1,0 +1,27 @@
+# Community forks and special-purpose cookiecutters
+
+This page collects community-maintained forks and special-purpose cookiecutter templates that extend or adapt Cookiecutter Data Science for narrower workflows. If you maintain a fork/template and would like it added here, please open a PR that adds a single bullet with the format shown below.
+
+## How to add your fork
+
+Please open a PR that adds *one bullet* under the relevant category with this format:
+
+`- [Project name](https://github.com/owner/repo) — Short one-line description — Maintainer: @github-username — Tags: tag1, tag2`
+
+Keep descriptions short (1–2 lines). We will curate the list for quality and relevance.
+
+## Examples
+
+- [cookiecutter-deeplearning](https://github.com/tdeboissiere/cookiecutter-deeplearning) — Project folder structure for deep learning work. Maintainer: @tdeboissiere — Tags: deeplearning.
+
+- [cookiecutter-snakemake-analysis-pipeline](https://github.com/xguse/cookiecutter-snakemake-analysis-pipeline) — Template for Snakemake-based analysis pipelines. Maintainer: @xguse — Tags: snakemake, workflow.
+
+
+## Notes for contributors
+
+* The linked repo should be public and have a clear README and license (MIT, Apache, etc.) where possible.
+* Only include actively maintained or clearly useful forks; maintainers may prune or re-categorize entries later.
+
+---
+
+*If you want more structure later we can change this to a small table (repo, purpose, tags, license).*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,61 @@
+site_name: Cookiecutter Data Science
+site_description: A project template and directory structure for Python data science projects.
+site_url: https://cookiecutter-data-science.drivendata.org
+repo_url: https://github.com/drivendataorg/cookiecutter-data-science
+edit_uri: edit/master/docs/docs
+copyright: Project maintained by the friendly folks at <a target=_blanks href="https://www.drivendata.org">DrivenData</a>.
+theme: 
+  favicon: favicon.ico
+  features:
+    - navigation.instant
+    - toc.integrate
+  logo: ccds.png
+  name: material
+  custom_dir: overrides
+  palette:
+    primary: custom
+    accent: custom
+  font:
+    text: Work Sans
+    code: Space Mono
+nav:
+  - Home: index.md
+  - Why ccds?: why.md
+  - Opinions: opinions.md
+  - Using the template: using-the-template.md
+  - All options: all-options.md
+  - Contributing: contributing.md
+  - Related projects: related.md
+  - v1 Template: v1.md
+  - Community forks: community-forks.md
+extra:
+  analytics:
+    provider: google
+    property: G-DX14MC19WY
+extra_css:
+  - css/extra.css
+extra_javascript:
+  - js/extra.js
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
+  - tables
+  - toc:
+      toc_depth: 2
+plugins:
+  - include-markdown
+  - termynal:
+      title: bash
+      buttons: macos
+      prompt_literal_start:
+        - "$"
+  - gen-files:
+      scripts:
+        - scripts/generate-termynal.py
+        - scripts/configuration-table.py


### PR DESCRIPTION
This PR adds a new documentation page (docs/community-forks.md) that lists community-maintained forks of cookiecutter-data-science for more specific purposes.  

Added links:
- Deep Learning fork: https://github.com/tdeboissiere/cookiecutter-deeplearning  
- Snakemake pipeline fork: https://github.com/xguse/cookiecutter-snakemake-analysis-pipeline  

Also updated mkdocs.yml to include this page in the documentation navigation.
