### PR TITLE
Drop Python 3.9 support (EOL)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,22 +51,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     defaults:
       run:
         shell: bash
 
     steps:
       - uses: actions/checkout@v4
-
-      # Poetry 2.3+ requires Python >=3.10 to install/run the CLI. Install a
-      # dedicated interpreter for Poetry before the matrix Python so the matrix
-      # version remains the default `python` on PATH for tests.
-      - name: Set up Python for Poetry CLI
-        id: poetry-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -91,10 +82,9 @@ jobs:
           run-install: false
   
       - name: Set up Poetry
-        run: |
-          python -m pip install --upgrade pipx
-          pipx install --python "${{ steps.poetry-python.outputs.python-path }}" poetry
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        uses: abatilo/actions-poetry@v3
+        with:
+          poetry-version: latest
 
       - name: Cache conda packages
         uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Poetry 2.3+ requires Python >=3.10 to install/run the CLI. Install a
+      # dedicated interpreter for Poetry before the matrix Python so the matrix
+      # version remains the default `python` on PATH for tests.
+      - name: Set up Python for Poetry CLI
+        id: poetry-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -82,9 +91,10 @@ jobs:
           run-install: false
   
       - name: Set up Poetry
-        uses: abatilo/actions-poetry@v3
-        with:
-          poetry-version: latest
+        run: |
+          python -m pip install --upgrade pipx
+          pipx install --python "${{ steps.poetry-python.outputs.python-path }}" poetry
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Cache conda packages
         uses: actions/cache@v4

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # cookiecutter-data-science Changelog
 
+## Next Release
+
+- Dropped CI & support for Python 3.9 (EOL).
+
 ## v2.3.0 (2025-07-23)
 
  - Added `pixi` as a new environment manager option (supports `pyproject.toml` and `pixi.toml`). (PR [#459](https://github.com/drivendataorg/cookiecutter-data-science/pull/459), Issue [#406](https://github.com/drivendataorg/cookiecutter-data-science/issues/406))

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - Dropped CI & support for Python 3.9 (EOL).
+- Fixed Windows CI failures when using pixi + ruff by excluding `.pixi` from Ruff discovery.
 
 ## v2.3.0 (2025-07-23)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _A logical, reasonably standardized but flexible project structure for doing and
 
 ## Installation
 
-Cookiecutter Data Science v2 requires Python 3.9+. Since this is a cross-project utility application, we recommend installing it with [pipx](https://pypa.github.io/pipx/). Installation command options:
+Cookiecutter Data Science v2 requires Python 3.10+. Since this is a cross-project utility application, we recommend installing it with [pipx](https://pypa.github.io/pipx/). Installation command options:
 
 ```bash
 # With pipx from PyPI (recommended)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -16,7 +16,7 @@ _A logical, flexible, and reasonably standardized project structure for doing an
 
 ## Quickstart
 
-Cookiecutter Data Science v2 requires Python 3.9+. Since this is a cross-project utility application, we recommend installing it with [pipx](https://pypa.github.io/pipx/). Installation command options:
+Cookiecutter Data Science v2 requires Python 3.10+. Since this is a cross-project utility application, we recommend installing it with [pipx](https://pypa.github.io/pipx/). Installation command options:
 
 === "With pipx (recommended)"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -28,7 +27,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   "click",
   "cookiecutter",

--- a/tests/pixi_harness.sh
+++ b/tests/pixi_harness.sh
@@ -46,7 +46,13 @@ if [ -f "$MODULE_NAME/config.py" ]; then
     pixi run python -c "from $MODULE_NAME import config"
 fi
 
-# Run linting and formatting through pixi
+# Run linting and formatting through pixi.
+# On Windows, conda/pixi Python installs can ship nested .ruff.toml files under
+# .pixi that break config discovery (extends a missing parent). Remove them.
+if [ -d ".pixi" ]; then
+    echo "Removing Ruff config files under .pixi to avoid discovery"
+    find .pixi \( -name ".ruff.toml" -o -name "ruff.toml" \) -print -delete
+fi
 pixi run make lint
 pixi run make format
 

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -36,6 +36,7 @@ force_sort_within_sections = true
 line-length = 99
 src = ["{{ cookiecutter.module_name }}"]
 include = ["pyproject.toml", "{{ cookiecutter.module_name }}/**/*.py"]
+extend-exclude = [".pixi"]
 
 [tool.ruff.lint]
 extend-select = ["I"]  # Add import sorting


### PR DESCRIPTION
## Summary
- Python 3.9 is EOL; remove it from the CI matrix, `requires-python`, classifiers, and docs.
- Fix Windows pixi + ruff failures: exclude `.pixi` from Ruff discovery and delete nested `.ruff.toml` files in the pixi test harness (same root cause as #432 / #473).

## Test plan
- [ ] CI passes on 3.10–3.13 across ubuntu/macOS/Windows
- [ ] Especially Windows: `pixi-pyproject.toml-*` and `pixi-pixi.toml-*` baking tests pass
- [ ] After merge, scheduled Sunday run (or `workflow_dispatch`) succeeds